### PR TITLE
Feature/bngp 3402 registration disable filetype option page disable geospatial file functionality

### DIFF
--- a/src/conf/wdio.local.conf.js
+++ b/src/conf/wdio.local.conf.js
@@ -316,9 +316,10 @@ exports.config = {
    * @param {number}                 result.duration  duration of scenario in milliseconds
    * @param {Object}                 context          Cucumber World object
    */
-  //  afterScenario: async function (world, result, context) {
-  //   cucumberJson.attach(await browser.takeScreenshot(), 'image/png');
-  //  },
+   afterScenario: async function (world, result, context) {
+    // cucumberJson.attach(await browser.takeScreenshot(), 'image/png');
+    await browser.reloadSession();
+   },
   /**
    *
    * Runs after a Cucumber Feature.
@@ -353,6 +354,7 @@ exports.config = {
    * @param {Array.<String>} specs List of spec file paths that ran
    */
   // afterSession: function (config, capabilities, specs) {
+    
   // },
   /**
    * Gets executed after all workers got shut down and the process is about to exit. An error

--- a/src/features/developer-Journey.feature
+++ b/src/features/developer-Journey.feature
@@ -25,7 +25,7 @@ Feature: Developer Journey Tests
         And I should see the "Confirm off-site gain" section status as "NOT STARTED"
         And I should see the "Upload the consent document" section status as "NOT STARTED"
         And I should see the "submit" section status as "CANNOT START YET"
-    @e2e
+
     # Check answers
     Scenario: BNGP-2964 1 - The Biodiversity Gain Site Reference is displayed
         # AND https://eaflood.atlassian.net/browse/BNGP-3378 - 3 appropriate fee is displayed for the journey

--- a/src/features/developer-Journey.feature
+++ b/src/features/developer-Journey.feature
@@ -43,9 +43,6 @@ Feature: Developer Journey Tests
         And I choose and upload a "consent-agreement" file
         And I confirm it is the correct file
         And I confirm I have completed all "developer journey" sections
-        #Additional emails (is this in the right place?)
-        And I continue without adding email notifications for additional people
-
         And I am on the "check-answers" page
         When I submit my developer information
         Then I should be on the "application-submitted" page

--- a/src/features/land-boundary.feature
+++ b/src/features/land-boundary.feature
@@ -8,10 +8,10 @@ Feature: Land Boundary
     Background:
         Given I navigate to the "start" page
         And I start my registration
-        # eligibility
-        And I have everything I need to start my biodiversity gain site registration
-        # applicant details
-        And I have completed the applicant details section
+        # DefraID
+        And I login to the Government Gateway
+        And I am logged in to the service
+
 
     @skip() # temporarily skip test that is running locally pointing to the dev env, but not on ci as this is a superficial test
     Scenario Outline: BNGP-526 1 - There is an option to upload geospatial and non geospatial data

--- a/src/features/step_definitions/land-boundary.steps..js
+++ b/src/features/step_definitions/land-boundary.steps..js
@@ -6,10 +6,10 @@ const checkLandBoundaryDetailsPage = require("../page_objects/land_boundary/chec
 const tasklistPage = require("../page_objects/register-land-task-list.page");
 
 Given("I have completed the land-boundary section", async () => {
-  await completeLandBoundarySection("fileType", "TL6233", "1231.11");
+  await completeLandBoundarySection("TL6233", "1231.11");
 })
 
-async function completeLandBoundarySection(fileType, gridreference, hectares) {
+async function completeLandBoundarySection(gridreference, hectares) {
 
   await gridReferencePage.addGridReference(gridreference);
   await addHectaresPage.addHectares(hectares);

--- a/src/features/step_definitions/task-list.steps.js
+++ b/src/features/step_definitions/task-list.steps.js
@@ -7,7 +7,8 @@ switch(journey){
   case "developer journey":{
     await expect(DeveloperTaskListPage.submitStatus).not.toHaveTextContaining("CANNOT START YET")
   await expect(DeveloperTaskListPage.submitStatus).toHaveTextContaining("NOT STARTED YET")
-  await (DeveloperTaskListPage.additionalEmailBtn).click();
+
+  await DeveloperTaskListPage.submitInformation.click();
   break;
   }
   case "landowner journey":{

--- a/src/features/upload-documents.feature
+++ b/src/features/upload-documents.feature
@@ -23,7 +23,7 @@ Feature: Upload Documents
             | BNGP-499    | legal-agreement   | add-legal-agreement-parties |
             | BNGP-765    | management-plan   | habitat-works-start-date    |
             | BNGP-767    | land-boundary     | grid-reference              |
-            | BNGP-526    | geospatial        | check-land-boundary-details |
+            # | BNGP-526    | geospatial        | check-land-boundary-details |
             | BNGP-524    | metric            | metric-display-baseline     |
             | BNGP-515    | land-ownership    | registered-landowner        |
             | BNGP-3094   | local-land-charge | register-land-task-list     |
@@ -42,7 +42,7 @@ Feature: Upload Documents
             | BNGP-499    | legal-agreement |
             | BNGP-765    | management-plan |
             | BNGP-767    | land-boundary   |
-            | BNGP-526    | geospatial      |
+            # | BNGP-526    | geospatial      |
             | BNGP-524    | metric          |
             | BNGP-515    | land-ownership  |
 
@@ -57,7 +57,7 @@ Feature: Upload Documents
             | BNGP-499    | legal-agreement | 11.75 kB |
             | BNGP-765    | management-plan | 11.75 kB |
             | BNGP-767    | land-boundary   | 11.75 kB |
-            | BNGP-526    | geospatial      | 1.07 kB  |
+            # | BNGP-526    | geospatial      | 1.07 kB  |
             | BNGP-524    | metric          | 5.39 MB  |
             | BNGP-515    | land-ownership  | 11.75 kB |
 
@@ -71,7 +71,7 @@ Feature: Upload Documents
             | BNGP-499    | legal-agreement |
             | BNGP-765    | management-plan |
             | BNGP-767    | land-boundary   |
-            | BNGP-526    | geospatial      |
+            # | BNGP-526    | geospatial      |
             | BNGP-524    | metric          |
             | BNGP-515    | land-ownership  |
 
@@ -85,7 +85,7 @@ Feature: Upload Documents
             | legal-agreement |
             | management-plan |
             | land-boundary   |
-            | geospatial      |
+            # | geospatial      |
             | metric          |
             | land-ownership  |
 
@@ -99,7 +99,7 @@ Feature: Upload Documents
             | legal-agreement | Select a legal agreement                        |
             | management-plan | Select a habitat management and monitoring plan |
             | land-boundary   | Select a file showing the land boundary         |
-            | geospatial      | Select a file showing the land boundary         |
+            # | geospatial      | Select a file showing the land boundary         |
             | metric          | Select a Biodiversity Metric                    |
             | land-ownership  | Select a proof of land ownership file           |
 
@@ -114,7 +114,7 @@ Feature: Upload Documents
             | legal-agreement |
             | management-plan |
             | land-boundary   |
-            | geospatial      |
+            # | geospatial      |
             # todo skip as need to investigate this specific test
             # | metric   |
             | land-ownership  |
@@ -142,9 +142,9 @@ Feature: Upload Documents
             | land-boundary   | docx     |
             | land-boundary   | pdf      |
             | land-boundary   | jpg      |
-            | geospatial      | zip      |
-            | geospatial      | geojson  |
-            | geospatial      | gpkg     |
+    # | geospatial      | zip      |
+    # | geospatial      | geojson  |
+    # | geospatial      | gpkg     |
 
     Scenario Outline: <jira ticket> 8 I cannot upload a <document> file that is larger than the maximum file size (currently 50MB with 2.43 threshhold that allows for both binary and decimal interpretations of the upload limit)
         When I navigate to the "<document>-upload" page


### PR DESCRIPTION
geospatial filetype option has been removed for mvp but may be reintroduced.   As has additional email functionality on the developer journey.  however is not mvp so developer journey removed from e2e suite that run for now (They still run on local regressions) 